### PR TITLE
MF/SPONSOR/ngxuc7g2e | MultidialogoClient now clears AuthProvider's

### DIFF
--- a/src/Auth/AuthProvider.php
+++ b/src/Auth/AuthProvider.php
@@ -178,4 +178,11 @@ class AuthProvider implements AuthProviderInterface
             throw new MultidialogoClientException("Authentication failed. (status code: {$response->getStatusCode()})");
         }
     }
+
+    public function reset()
+    {
+        $this->authToken = null;
+        $this->refreshToken = null;
+        $this->tokenStorage->reset($this->username);
+    }
 }

--- a/src/Auth/AuthProviderInterface.php
+++ b/src/Auth/AuthProviderInterface.php
@@ -5,4 +5,6 @@ namespace multidialogo\client\Auth;
 interface AuthProviderInterface
 {
     public function getToken();
+
+    public function reset();
 }

--- a/src/Auth/FileTokenStorage.php
+++ b/src/Auth/FileTokenStorage.php
@@ -75,4 +75,10 @@ class FileTokenStorage implements TokenStorageInterface
     }
 
 
+    function reset($userName)
+    {
+        $fileName = $this->getFileName($userName);
+
+        unlink($fileName);
+    }
 }

--- a/src/Auth/TokenStorageInterface.php
+++ b/src/Auth/TokenStorageInterface.php
@@ -19,4 +19,9 @@ interface TokenStorageInterface
      * @param AuthToken $refreshToken
      */
     function write($userName, $mainToken, $refreshToken);
+
+    /**
+     * @param string $userName
+     */
+    function reset($userName);
 }

--- a/src/Auth/TokenWrapper.php
+++ b/src/Auth/TokenWrapper.php
@@ -18,4 +18,9 @@ class TokenWrapper implements AuthProviderInterface
     {
         return $this->token;
     }
+
+    public function reset()
+    {
+        $this->token = null;
+    }
 }

--- a/src/Auth/VolatileTokenStorage.php
+++ b/src/Auth/VolatileTokenStorage.php
@@ -27,4 +27,10 @@ class VolatileTokenStorage implements TokenStorageInterface
         $this->mainToken = $mainToken;
         $this->refreshToken = $refreshToken;
     }
+
+    function reset($userName)
+    {
+        $this->mainToken = null;
+        $this->refreshToken = null;
+    }
 }

--- a/src/MultidialogoClient.php
+++ b/src/MultidialogoClient.php
@@ -5,8 +5,8 @@ namespace multidialogo\client;
 use Exception;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
-use multidialogo\client\Auth\AuthProvider;
 use multidialogo\client\Auth\AuthProviderInterface;
 use multidialogo\client\Exception\MultidialogoClientException;
 use Psr\Http\Message\ResponseInterface;
@@ -116,9 +116,9 @@ class MultidialogoClient
         try {
             return $this->httpClient->request($method, $url, $this->options);
         } catch (ClientException $e) {
-            $responseBody = $e->getResponse()->getBody()->getContents();
+            $this->authProvider->reset();
 
-            throw new MultidialogoClientException("Request error. Code: {$e->getResponse()->getStatusCode()}, body: {$responseBody}", $e);
+            return new Response(401, []);
         } catch (Exception $e) {
             throw new MultidialogoClientException("Request error. {$e->getMessage()}", $e);
         }

--- a/test/AuthProviderTest.php
+++ b/test/AuthProviderTest.php
@@ -16,9 +16,9 @@ use multidialogo\client\Auth\AuthProvider;
 use multidialogo\client\Auth\AuthToken;
 use multidialogo\client\Auth\FileTokenStorage;
 use multidialogo\client\Auth\VolatileTokenStorage;
+use multidialogo\client\test\TestUtils\AuthPayloadUtils;
 use multidialogo\client\test\TestUtils\JsonResources;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use function PHPUnit\Framework\assertEquals;
 
 class AuthProviderTest extends TestCase
@@ -109,8 +109,8 @@ json;
         $history = Middleware::history($container);
 
         $now = new DateTimeImmutable("now", new DateTimeZone("UTC"));
-        $user1OkResponseObj = $this->setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
-        $user2OkResponseObj = $this->setExpireDatesAtDate($now, self::USER2_OK_RESPONSE);
+        $user1OkResponseObj = AuthPayloadUtils::setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
+        $user2OkResponseObj = AuthPayloadUtils::setExpireDatesAtDate($now, self::USER2_OK_RESPONSE);
 
         $mock = new MockHandler([
             new Response(201, [], json_encode($user1OkResponseObj)),
@@ -174,18 +174,6 @@ json;
         self::assertCount(2, $container);
     }
 
-    private function setExpireDatesAtDate(DateTimeImmutable $startDate, string $tokenPayload): stdClass
-    {
-        $tokenObj = json_decode($tokenPayload);
-        $tokenObj->data->attributes->createdAt = $startDate->format('Y-m-d\TH:i:s\Z');
-        $expireAt = $startDate->add(new DateInterval("PT3H"));
-        $tokenObj->data->attributes->expireAt = $expireAt->format('Y-m-d\TH:i:s\Z');
-        $refreshExpireAt = $startDate->add(new DateInterval("P15D"));
-        $tokenObj->data->attributes->refreshTokenExpireAt = $refreshExpireAt->format('Y-m-d\TH:i:s\Z');
-
-        return $tokenObj;
-    }
-
     public function testShouldCallAuthenticateWhenNoTokenAreStored()
     {
         $user1UserName = 'user1@some_domain.com';
@@ -199,7 +187,7 @@ json;
         $history = Middleware::history($container);
 
         $now = new DateTimeImmutable("now", new DateTimeZone("UTC"));
-        $user1OkResponseObj = $this->setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
+        $user1OkResponseObj = AuthPayloadUtils::setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
 
         $mock = new MockHandler([
             new Response(201, [], json_encode($user1OkResponseObj)),
@@ -245,7 +233,7 @@ json;
 
         $now = new DateTimeImmutable("now", new DateTimeZone("UTC"));
 
-        $user1OkResponseObj = $this->setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
+        $user1OkResponseObj = AuthPayloadUtils::setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
 
         $mock = new MockHandler([
             new Response(201, [], json_encode($user1OkResponseObj)),
@@ -289,7 +277,7 @@ json;
         $history = Middleware::history($container);
 
         $now = new DateTimeImmutable("now", new DateTimeZone("UTC"));
-        $user1OkResponseObj = $this->setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
+        $user1OkResponseObj = AuthPayloadUtils::setExpireDatesAtDate($now, self::USER1_OK_RESPONSE);
 
         $mock = new MockHandler([
             new Response(201, [], json_encode($user1OkResponseObj)),

--- a/test/MultidialogoClientTest.php
+++ b/test/MultidialogoClientTest.php
@@ -2,7 +2,18 @@
 
 namespace multidialogo\client\test;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use multidialogo\client\Auth\AuthProvider;
+use multidialogo\client\Auth\FileTokenStorage;
+use multidialogo\client\Common\DateTimeUtils;
 use multidialogo\client\MultidialogoClient;
+use multidialogo\client\test\TestUtils\AuthPayloadUtils;
 use PHPUnit\Framework\TestCase;
 
 class MultidialogoClientTest extends TestCase
@@ -20,5 +31,81 @@ class MultidialogoClientTest extends TestCase
         $client->getJson('geo/countries');
 
         self::assertEquals('Bearer ' . $token, $client->getLastRequestHeaders()['Authorization']);
+    }
+
+    private const USER_TEST_OK_RESPONSE = <<<json
+        {
+            "status": "CREATED",
+            "data": {
+                "id": "25ad1beadfeb089cb5bd0ea20da8a610.0004178967cf186762382528d7e994ba081z8111551061",
+                "type": "auth-tokens",
+                "attributes": {
+                    "token": "USER_TEST_OK_RESPONSE_TOKEN",
+                    "category": "Bearer",
+                    "createdAt": "2022-12-01T11:18:38Z",
+                    "expireAt": "2022-12-01T14:18:38Z",
+                    "refreshToken": "USER_TEST_OK_RESPONSE_REFRESH_TOKEN",
+                    "refreshTokenExpireAt": "2023-12-16T11:18:38Z"
+                }
+            }
+        }
+json;
+
+    public function testWillRecoverFromAccessDenied()
+    {
+        $container = [];
+        $history = Middleware::history($container);
+
+        $userTestOkResponseObj = AuthPayloadUtils::setExpireDatesAtDate(DateTimeUtils::utcNow(), self::USER_TEST_OK_RESPONSE);
+
+        $mock = new MockHandler([
+            new Response(201, [], json_encode($userTestOkResponseObj)),
+            new Response(201, [], json_encode($userTestOkResponseObj)),
+            new ClientException('AccessDenied', new Request('GET', 'geo/countries'), new Response(401, [], "[]")),
+            new Response(201, [], json_encode($userTestOkResponseObj)),
+            new Response(201, [], json_encode($userTestOkResponseObj)),
+        ]);
+
+        $handlerStack = new HandlerStack($mock);
+
+        $handlerStack->push($history);
+
+        $httpClient = new Client([
+            'base_uri' => 'http://backend',
+            'handler' => $handlerStack
+        ]);
+
+        $tokenStorage = new FileTokenStorage(__DIR__ . '/TestUtils/FileTokenStorage');
+
+        $username = 'test_reset';
+        $password = 'pass';
+
+        $authProvider = new AuthProvider(
+            $httpClient,
+            $tokenStorage,
+            $username,
+            $password
+        );
+
+        $client = new MultidialogoClient($httpClient, $authProvider, []);
+
+        $client->setLanguage('it');
+
+        // 1. first call will go through login to get first tokens pair
+        $client->getJson('geo/countries');
+
+        // 2. second call will NOT call login (since it has a apparently valid tokens pair)
+        // but get 401
+        $client->getJson('geo/countries');
+
+        // 3. third call will go through login since tokens pair was cleared in previous step
+        $client->getJson('geo/countries');
+
+        self::assertCount(5, $container);
+        self::assertEquals('/users/login', $container[0]['request']->getUri()->getPath());
+        self::assertEquals('/geo/countries', $container[1]['request']->getUri()->getPath());
+        self::assertEquals('/geo/countries', $container[2]['request']->getUri()->getPath());
+        self::assertEquals('/users/login', $container[3]['request']->getUri()->getPath());
+        self::assertEquals('/geo/countries', $container[4]['request']->getUri()->getPath());
     }
 }

--- a/test/TestUtils/AuthPayloadUtils.php
+++ b/test/TestUtils/AuthPayloadUtils.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace multidialogo\client\test\TestUtils;
+
+use DateInterval;
+use DateTimeImmutable;
+use stdClass;
+
+class AuthPayloadUtils
+{
+    public static function setExpireDatesAtDate(DateTimeImmutable $startDate, string $tokenPayload): stdClass
+    {
+        $tokenObj = json_decode($tokenPayload);
+        $tokenObj->data->attributes->createdAt = $startDate->format('Y-m-d\TH:i:s\Z');
+        $expireAt = $startDate->add(new DateInterval("PT3H"));
+        $tokenObj->data->attributes->expireAt = $expireAt->format('Y-m-d\TH:i:s\Z');
+        $refreshExpireAt = $startDate->add(new DateInterval("P15D"));
+        $tokenObj->data->attributes->refreshTokenExpireAt = $refreshExpireAt->format('Y-m-d\TH:i:s\Z');
+
+        return $tokenObj;
+    }
+}


### PR DESCRIPTION
When AuthProvider has _valid_ tokens it happens that backend does not validate them, for any reason.
In this case MultidialogoClient now clears the stored tokens, to force a new login in the subsequent call.